### PR TITLE
Fixed rank searching

### DIFF
--- a/Report.py
+++ b/Report.py
@@ -6,7 +6,7 @@ name = input("Enter first and last name ")
 userName = input("What is your username in game")
 summoner = kassadin.get_summoner(name=userName)
 level = summoner.level
-rank_last_season = summoner.rank_last_season
+rank = summoner.league_entries
 this_mans_champion_masteries = summoner.champion_masteries
 favoriteRoles = []
 while True:
@@ -24,15 +24,16 @@ while True:
         favoriteChampions.append(champions)
 
 
-def player_report(player_name, user_name, player_level, player_role, player_favorite_champions, player_rank_last_season, this_mans_champion_masteries):
+def player_report(player_name, user_name, player_level, player_role, player_favorite_champions, player_rank, this_mans_champion_masteries):
     print("=== LEAGUE PLAYER REPORT ===")
     print(f"Full name is {player_name}")
     print(f"Username is {user_name}")
     print(f"Level is {player_level}")
     print(player_role)
     print(player_favorite_champions)
-    print(player_rank_last_season)
+    print(f"Current Solo/Duo rank: {player_rank.fives.tier}")
+    print(f"Current Flex rank: {player_rank.flex.tier}")
     print(this_mans_champion_masteries)
 
 
-player_report(name, userName, level, favoriteRoles, favoriteChampions, rank_last_season, this_mans_champion_masteries)
+player_report(name, userName, level, favoriteRoles, favoriteChampions, rank, this_mans_champion_masteries)


### PR DESCRIPTION
`rank_last_season` is deprecated in the cass api. Replaced with even better current rank lookup, grabs current solo/duo and flex rank for profiles.